### PR TITLE
Set correct path for grub themes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 include(LiriSetup)
 
 ## Grub directory
-set(INSTALL_GRUBDIR "boot/grub" CACHE PATH "Grub [boot/grub]")
+set(INSTALL_GRUBDIR "/boot/grub" CACHE PATH "Grub [/boot/grub]")
 
 ## Add subdirectories:
 add_subdirectory(colorschemes)


### PR DESCRIPTION
In it's infinite wisdom cmake installed themes to /usr/boot/grub

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>